### PR TITLE
Refactor comment_map to be by section containing keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ exclude_lines =[
     "pragma: no cover",
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
     "\\.\\.\\.",
 ]
 

--- a/tests/expected.ini
+++ b/tests/expected.ini
@@ -11,6 +11,8 @@ logging=true
 
 [NEW SECTION]
 # Another comment
+foo=bar
+# Unique foo
 multi-line=
 	value01
 	value02

--- a/tests/withcomments.ini
+++ b/tests/withcomments.ini
@@ -12,6 +12,8 @@ logging=true
 	; and many could be between things
 [NEW SECTION]
 # Another comment
+foo=bar
+# Unique foo
 multi-line=
 	value01
 	value02


### PR DESCRIPTION
This change ensures that `DEFAULT : foo` and `SAMPLE : foo` are uniquely mapped in the comment_map dictionary as they are unique sections:key in the config file.

This will allow more control over handling keys that are removed.