### PR TITLE
Preserve comments of deleted sections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commented-configparser"
-version = "0.0.1"
+version = "1.0.0"
 requires-python = ">=3.7"
 description = "Custom ConfigParser class that preserves comments in file when writing"
 readme = "README.md"

--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -129,12 +129,7 @@ class CommentedConfigParser(ConfigParser):
         # Capture all trailing lines in comment_lines on exit of loop
         comment_map[section][key] = comment_lines.copy()
 
-        # Discard any keys that have an empty value
-        clean_map: dict[str, dict[str, list[str]]] = {}
-        for key, value in comment_map.items():
-            clean_map[key] = {k: v for k, v in value.items() if v}
-
-        self._comment_map = clean_map
+        self._comment_map = comment_map
 
     def _restore_comments(self, content: str) -> str:
         """Restore comments from internal map."""

--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -184,8 +184,14 @@ class CommentedConfigParser(ConfigParser):
 
         orphaned_comments: list[str] = []
         for key in mapped_keys:
+
+            # Key no longer exists, gather comments and loop upward
             if key != "@@header" and key not in config_keys:
                 orphaned_comments.extend(self._comment_map[section].pop(key))
+
             else:
+                # Drop everything in the next key that exists
+                # @@header always exists
+                # TODO: comments will be in reverse order, handle that
                 self._comment_map[section][key].extend(orphaned_comments)
                 orphaned_comments.clear()

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -275,6 +275,43 @@ def test_merge_deleted_keys() -> None:
     assert cc._comment_map == {"[TEST]": {"@@header": ["# Test comment"]}}
 
 
+def test_merge_multiple_deleted_keys_retain_order() -> None:
+    cc = CommentedConfigParser()
+    cc.read_dict({"TEST": {"foo": "bar"}})
+    cc._comment_map = {
+        "[TEST]": {
+            "@@header": [],
+            "foo": [
+                "# This is foo's comment",
+            ],
+            "test": [
+                "# Test comment line 1",
+                "# Test comment line 2",
+            ],
+            "removed": [
+                "# Test comment line 3",
+                "# Test comment line 4",
+            ],
+        },
+    }
+    expected = {
+        "[TEST]": {
+            "@@header": [],
+            "foo": [
+                "# This is foo's comment",
+                "# Test comment line 1",
+                "# Test comment line 2",
+                "# Test comment line 3",
+                "# Test comment line 4",
+            ],
+        },
+    }
+
+    cc._merge_deleted_keys("[TEST]")
+
+    assert cc._comment_map == expected
+
+
 def test_write_with_comments_single_file_remove_key() -> None:
     cc = CommentedConfigParser()
     mod_expected = EXPECTED_STR.replace("foo=bar\n", "", 1)

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -22,6 +22,7 @@ EXPECTED_MAP = {
         "foo": [
             "# Make sure to add this when you need it",
         ],
+        "trace": [],
         "logging": [
             "; This is a comment as well",
             "    # so we need to track all of them",
@@ -29,12 +30,14 @@ EXPECTED_MAP = {
         ],
     },
     "[NEW SECTION]": {
-        "@@header": [
-            "# Another comment",
-        ],
+        "@@header": [],
         "foo": [
             "# Unique foo",
         ],
+        "multi-line": [],
+        "value01": [],
+        "value02": [],
+        "value03": [],
         "closing": [
             "# Trailing comment",
         ],
@@ -260,6 +263,17 @@ def test_write_with_no_comments() -> None:
     cc.write(mock_file, space_around_delimiters=False)
 
     assert mock_file.getvalue() == expected
+
+
+# @pytest.mark.skip(reason="WIP")
+# def test_merge_deleted_keys() -> None:
+#     cc = CommentedConfigParser()
+#     cc.read_dict({"TEST": {"test": "pass"}})
+#     cc._comment_map = {"[TEST]": {"@@header": [], "test": ["# Test comment"]}}
+
+#     cc._merge_deleted_keys("[TEST]")
+
+#     assert cc._comment_map == {"[TEST]": {"@@header": ["# Test comment"]}}
 
 
 @pytest.mark.skip(reason="WIP")

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -285,3 +285,11 @@ def test_write_with_comments_single_file_remove_key() -> None:
     cc.write(mock_file, space_around_delimiters=False)
 
     assert mock_file.getvalue() == mod_expected
+
+
+def test_restore_comments_no_comments() -> None:
+    cc = CommentedConfigParser()
+
+    result = cc._restore_comments("This is only a test")
+
+    assert result == "This is only a test"

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -265,21 +265,19 @@ def test_write_with_no_comments() -> None:
     assert mock_file.getvalue() == expected
 
 
-# @pytest.mark.skip(reason="WIP")
-# def test_merge_deleted_keys() -> None:
-#     cc = CommentedConfigParser()
-#     cc.read_dict({"TEST": {"test": "pass"}})
-#     cc._comment_map = {"[TEST]": {"@@header": [], "test": ["# Test comment"]}}
+def test_merge_deleted_keys() -> None:
+    cc = CommentedConfigParser()
+    cc.read_dict({"TEST": {}})
+    cc._comment_map = {"[TEST]": {"@@header": [], "test": ["# Test comment"]}}
 
-#     cc._merge_deleted_keys("[TEST]")
+    cc._merge_deleted_keys("[TEST]")
 
-#     assert cc._comment_map == {"[TEST]": {"@@header": ["# Test comment"]}}
+    assert cc._comment_map == {"[TEST]": {"@@header": ["# Test comment"]}}
 
 
-@pytest.mark.skip(reason="WIP")
 def test_write_with_comments_single_file_remove_key() -> None:
     cc = CommentedConfigParser()
-    mod_expected = EXPECTED_STR.replace("foo=bar\n", "")
+    mod_expected = EXPECTED_STR.replace("foo=bar\n", "", 1)
     cc.read_string(CONFIG_W_COMMENTS_STR)
     mock_file = StringIO()
 

--- a/tests/expected.ini
+++ b/tests/expected.ini
@@ -10,7 +10,6 @@ logging=true
 	; and many could be between things
 
 [NEW SECTION]
-# Another comment
 foo=bar
 # Unique foo
 multi-line=

--- a/tests/withcomments.ini
+++ b/tests/withcomments.ini
@@ -11,7 +11,6 @@ logging=true
 
 	; and many could be between things
 [NEW SECTION]
-# Another comment
 foo=bar
 # Unique foo
 multi-line=


### PR DESCRIPTION
closes #5 

This change reintroducing holding all of the config keys, by section, in the `_comment_map` dictionary. We need the empty sections/keys to know they could exist when merging comments from deleted sections.
