### PR TITLE
fix different cases  between read() and write()

### DIFF
--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -25,6 +25,9 @@ class CommentedConfigParser(ConfigParser):
 
     _comment_map: dict[str, dict[str, list[str]]] | None = None
 
+    def optionxform(self, optionstr):
+        return optionstr
+
     def read(
         self,
         filenames: StrOrBytesPath | Iterable[StrOrBytesPath],
@@ -128,7 +131,7 @@ class CommentedConfigParser(ConfigParser):
                     section = self._get_key(line)
                     key = "@@header"
                 else:
-                    key = self._get_key(line)
+                    key = self.optionxform(self._get_key(line))
 
         # Capture all trailing lines in comment_lines on exit of loop
         comment_map[section][key] = comment_lines.copy()


### PR DESCRIPTION
Fix different cases between option names and key names in _comment_map

When read() and write() - options saves same cases