### PR TITLE
Remove support for 3.8, add 3.14

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,12 +25,12 @@ jobs:
           - "windows-latest"
           - "ubuntu-latest"
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - name: "Repo checkout"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads)
+[![Python 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14](https://img.shields.io/badge/Python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/downloads)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ nox.options.sessions = [
 
 
 @nox.session(
-    python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    python=["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"],
 )
 def tests_with_coverage(session: nox.Session) -> None:
     """Run unit tests with coverage saved to partial file."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,39 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm"]
+requires = [ "setuptools", "setuptools_scm" ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "commented-configparser"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 description = "Custom ConfigParser class that preserves comments in file when writing"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
 authors = [
     { email = "preocts@preocts.com", name = "Preocts" }
 ]
 maintainers = []
 keywords = []
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython"
 ]
-dynamic = ["dependencies", "optional-dependencies", "version"]
+dynamic = [ "dependencies", "optional-dependencies", "version" ]
 
 [tool.setuptools_scm]
 
 [tool.setuptools.dynamic.dependencies]
-file = ["requirements/requirements.txt"]
+file = [ "requirements/requirements.txt" ]
 
 [tool.setuptools.dynamic.optional-dependencies]
-dev = { file = ["requirements/requirements-dev.txt"] }
-test = { file = ["requirements/requirements-test.txt"] }
+dev = { file = [ "requirements/requirements-dev.txt" ] }
+test = { file = [ "requirements/requirements-test.txt" ] }
 
 [project.urls]
 homepage = "https://github.com/Preocts/commented-configparser"
 
 [tool.setuptools.package-data]
-"commentedconfigparser" = ["py.typed"]
+"commentedconfigparser" = [ "py.typed" ]
 
 [tool.mypy]
 check_untyped_defs = true
@@ -52,22 +51,12 @@ disallow_untyped_defs = false
 
 [tool.coverage.run]
 branch = true
-source = [
-    "tests",
-]
-source_pkgs = [
-    "commentedconfigparser",
-]
+source = [ "tests" ]
+source_pkgs = [ "commentedconfigparser" ]
 
 [tool.coverage.paths]
-source = [
-    "src/",
-    "*/site-packages",
-]
-test = [
-    "tests/",
-    "*/tests",
-]
+source = [ "src/", "*/site-packages" ]
+test = [ "tests/", "*/tests" ]
 
 [tool.coverage.report]
 exclude_lines =[


### PR DESCRIPTION
A little late to the party but removing support for Python 3.8 which went end-of-life last year. Adding in support for Python 3.14.

A linting of `pyproject.toml` and an adjustment of how the `project.license` property is defined also snuck into this change.