### PR TITLE
Refine trusted publishing workflows

### DIFF
--- a/.github/workflows/pypi-test-publish.yml
+++ b/.github/workflows/pypi-test-publish.yml
@@ -1,4 +1,4 @@
-name: "Publish Python distribution to PyPI"
+name: "Publish Python distribution to PyPI Test"
 # Uses:
 # https://github.com/actions/setup-python : a26af69be951a213d495a4c3e4e4022e16d87065
 # https://github.com/actions/checkout : 11bd71901bbe5b1630ceea73d27597364c9af683
@@ -7,8 +7,9 @@ name: "Publish Python distribution to PyPI"
 # https://github.com/actions/pypa/gh-action-pypi-publish : 76f52bc884231f62b9a034ebfe128415bbaabdfc
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[a-z]+[0-9]+"
 
 jobs:
   build:
@@ -41,8 +42,8 @@ jobs:
     needs: ["build"]
     runs-on: "ubuntu-latest"
     environment:
-      name: "pypi"
-      url: "https://pypi.org/project/commented-configparser/"
+      name: "testpypi"
+      url: "https://test.pypi.org/project/commented-configparser/"
     permissions:
       id-token: "write"
 
@@ -57,5 +58,5 @@ jobs:
       - name: "Publish distribution to PyPI"
         uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc"
         with:
-          repository-url: "https://upload.pypi.org/legacy/"
+          repository-url: "https://test.pypi.org/legacy/"
           verbose: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,9 +1,9 @@
 name: "python tests and coverage"
 # Uses:
-# https://github.com/actions/setup-python : 0b93645e9fea7318ecaed2b359559ac225c90a2b
+# https://github.com/actions/setup-python : a26af69be951a213d495a4c3e4e4022e16d87065
 # https://github.com/actions/checkout : 11bd71901bbe5b1630ceea73d27597364c9af683
-# https://github.com/actions/download-artifact : fa0a91b85d4f404e444e00e005971372dc801d16
-# https://github.com/actions/upload-artifact : 6f51ac03b9356f520e9adb1b1b7802705f340c2b
+# https://github.com/actions/download-artifact : d3f86a106a0bac45b974a628896c90dbdf5c8093
+# https://github.com/actions/upload-artifact : ea165f8d65b6e75b540449e92b4886f43607fa02
 
 on:
   pull_request:
@@ -46,7 +46,7 @@ jobs:
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b"
+        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
@@ -60,7 +60,7 @@ jobs:
           nox --session test -- partial-coverage
 
       - name: "Save coverage artifact"
-        uses: "actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b"
+        uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
         with:
           name: "coverage-artifact-${{ matrix.os}}-${{ matrix.python-version}}"
           path: ".coverage.*"
@@ -76,7 +76,7 @@ jobs:
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
 
       - name: "Set up Python"
-        uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b"
+        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
         with:
           python-version: "${{ needs.settings.outputs.default-python-version }}"
 
@@ -85,7 +85,7 @@ jobs:
           python -m pip install --upgrade nox
 
       - name: "Download coverage artifacts"
-        uses: "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16"
+        uses: "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
         with:
           pattern: "coverage-artifact-*"
           merge-multiple: true
@@ -106,7 +106,7 @@ jobs:
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
 
       - name: "Set up Python"
-        uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b"
+        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
         with:
           python-version: "${{ needs.settings.outputs.default-python-version }}"
 


### PR DESCRIPTION
*The path to improvement is paved with failed deployment attempts.*

This change adds the ability to test a publish to pypi using the trusted publishing action. Originally my intention was to extract the bulk of the work into a local reusable action but it turns out that isn't supported at the moment. Alas.

This change also bumps all the pinned hashes for actions. Mainly driven by download-artifact not supporting `artifact-ids` as a method to download a specific artifact.
