### PR TITLE
Mark global statics as internal

### DIFF
--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 
 __all__ = ["CommentedConfigParser"]
 
-COMMENT_PATTERN = re.compile(r"^\s*[#|;]\s*(.+)$")
-COMMENT_OPTION_PATTERN = re.compile(r"^(\s*)?__comment_\d+\s?[=|:]\s?(.*)$")
-KEY_PATTERN = re.compile(r"^(.+?)\s?[=|:].*$")
-SECTION_PATTERN = re.compile(r"^\s*\[(.+)\]\s*$")
+_COMMENT_PATTERN = re.compile(r"^\s*[#|;]\s*(.+)$")
+_COMMENT_OPTION_PATTERN = re.compile(r"^(\s*)?__comment_\d+\s?[=|:]\s?(.*)$")
+_KEY_PATTERN = re.compile(r"^(.+?)\s?[=|:].*$")
+_SECTION_PATTERN = re.compile(r"^\s*\[(.+)\]\s*$")
 
 
 class CommentedConfigParser(ConfigParser):
@@ -84,7 +84,7 @@ class CommentedConfigParser(ConfigParser):
 
         translated_lines = []
         for idx, line in enumerate(content):
-            if SECTION_PATTERN.match(line):
+            if _SECTION_PATTERN.match(line):
                 seen_section = True
 
             if not seen_section:
@@ -93,12 +93,12 @@ class CommentedConfigParser(ConfigParser):
                 # invalid config format.
                 self._headers.append(line)
 
-            elif COMMENT_PATTERN.match(line):
+            elif _COMMENT_PATTERN.match(line):
                 # Translate the comment into an option for the section. These
                 # are handled by the parent and retain order of insertion.
                 line = f"__comment_{self._commentprefix}{idx}={line.lstrip()}"
 
-            elif KEY_PATTERN.match(line) or SECTION_PATTERN.match(line):
+            elif _KEY_PATTERN.match(line) or _SECTION_PATTERN.match(line):
                 # Strip the left whitespace from sections and keys. This will
                 # leave only multiline values with leading whitespace preventing
                 # the saved output from incorrectly indenting after a comment
@@ -121,7 +121,7 @@ class CommentedConfigParser(ConfigParser):
             rendered += self._headers
 
         for line in content.splitlines():
-            comment_match = COMMENT_OPTION_PATTERN.match(line)
+            comment_match = _COMMENT_OPTION_PATTERN.match(line)
             if comment_match:
                 line = comment_match.group(2)
 

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -23,7 +23,7 @@ from commentedconfigparser.commentedconfigparser import CommentedConfigParser
     ),
 )
 def test_comment_pattern(line: str, expected: bool) -> None:
-    result = commentedconfigparser.COMMENT_PATTERN.match(line)
+    result = commentedconfigparser._COMMENT_PATTERN.match(line)
 
     assert bool(result) is expected
 
@@ -40,7 +40,7 @@ def test_comment_pattern(line: str, expected: bool) -> None:
     ),
 )
 def test_section_pattern(line: str, expected: bool) -> None:
-    result = commentedconfigparser.SECTION_PATTERN.match(line)
+    result = commentedconfigparser._SECTION_PATTERN.match(line)
 
     assert bool(result) is expected
 
@@ -61,7 +61,7 @@ def test_section_pattern(line: str, expected: bool) -> None:
 )
 def test_key_pattern(line: str, expected: str) -> None:
 
-    match = commentedconfigparser.KEY_PATTERN.match(line)
+    match = commentedconfigparser._KEY_PATTERN.match(line)
 
     assert match
     assert match.group(1) == expected
@@ -77,7 +77,7 @@ def test_key_pattern(line: str, expected: str) -> None:
 )
 def test_comment_option_pattern(line: str, expected: str) -> None:
 
-    match = commentedconfigparser.COMMENT_OPTION_PATTERN.match(line)
+    match = commentedconfigparser._COMMENT_OPTION_PATTERN.match(line)
 
     assert match
     assert match.group(2) == expected


### PR DESCRIPTION
Just a small flavour change to prefix the global statics with `_` as they are considered internal implementation.