### PR TITLE
Remove pre-commit from dev setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,27 +6,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"
     hooks:
-      - id: check-json
-      - id: check-toml
-      - id: check-yaml
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: check-docstring-first
-
-  # Adds a standard feel to import segments
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-        args:
-          - "--force-single-line-imports"
-          - "--add-import"
-          - "from __future__ import annotations"
-          - "--profile"
-          - "black"
-
-  # Format code. No, I don't like everything black does either.
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black
+      - id: mixed-line-ending

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,3 @@ nox -s update-deps
 ```bash
 nox -s upgrade-deps
 ```
-
----
-
-## [pre-commit](https://pre-commit.com)
-
-> A framework for managing and maintaining multi-language pre-commit hooks.
-
-This repo is setup with a `.pre-commit-config.yaml` with the expectation that
-any code submitted for review already passes all selected pre-commit checks.

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,9 +75,6 @@ def dev(session: nox.Session) -> None:
 
     python("pip", "install", "--editable", ".[dev,test]", *contraint, external=True)
 
-    python("pip", "install", "pre-commit", external=True)
-    session.run(f"{venv_path}/pre-commit", "install", external=True)
-
     if not os.environ.get("VIRTUAL_ENV"):
         session.log(f"\n\nRun '{activate_command}' to enter the virtual environment.\n")
 


### PR DESCRIPTION
`nox --session lint` covers the checks that are expected and usually require the dev to take action. Peeling back all the hooks in `.pre-commit-config.yaml` to only include self-healing nits.