### PR TITLE
Preserve empty comment lines

### DIFF
--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 __all__ = ["CommentedConfigParser"]
 
-_COMMENT_PATTERN = re.compile(r"^\s*[#|;]\s*(.+)$")
+_COMMENT_PATTERN = re.compile(r"^\s*[#|;]\s*(.*)$")
 _COMMENT_OPTION_PATTERN = re.compile(r"^(\s*)?__comment_\d+\s?[=|:]\s?(.*)$")
 _KEY_PATTERN = re.compile(r"^(.+?)\s?[=|:].*$")
 _SECTION_PATTERN = re.compile(r"^\s*\[(.+)\]\s*$")

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -20,6 +20,8 @@ from commentedconfigparser.commentedconfigparser import CommentedConfigParser
         ("  \tThis is a comment", False),
         ("", False),
         ("  \t", False),
+        ("#", True),
+        ("#\t", True),
     ),
 )
 def test_comment_pattern(line: str, expected: bool) -> None:
@@ -149,6 +151,7 @@ def test_write_with_no_comments() -> None:
 @pytest.mark.parametrize(
     ("ini_in", "ini_expected"),
     (
+        (["empty_comments_input.ini"], "empty_comments_expected.ini"),
         (["header_input.ini"], "header_expected.ini"),
         (["pydocs_input.ini"], "pydocs_expected.ini"),
         (["regression_original_input.ini"], "regression_original_expected.ini"),

--- a/tests/empty_comments_expected.ini
+++ b/tests/empty_comments_expected.ini
@@ -1,0 +1,15 @@
+# This has some headers
+#
+# These are comments that happen before any sections are defined
+
+[DEFAULT]
+foo = bar
+# Comment here
+#
+bar = foo
+;
+; Comment here too
+
+[BIZ]
+baz = bar
+

--- a/tests/empty_comments_input.ini
+++ b/tests/empty_comments_input.ini
@@ -1,0 +1,16 @@
+# This has some headers
+#
+# These are comments that happen before any sections are defined
+
+[DEFAULT]
+foo = bar
+
+# Comment here
+#
+bar = foo
+;
+; Comment here too
+
+
+[BIZ]
+baz=bar


### PR DESCRIPTION
issue #68 brought to light the fact that an empty comment line was being dropped, because the regex was looking for `(.+)` to be following the comment marker.