### PR TITLE
Remove extra newline created on write

### DIFF
--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -127,4 +127,7 @@ class CommentedConfigParser(ConfigParser):
 
             rendered.append(line + "\n")
 
+        # Remove extra trailing newline
+        rendered[-1] = rendered[-1].rstrip()
+
         return "".join(rendered)

--- a/tests/commentedconfigparser_test.py
+++ b/tests/commentedconfigparser_test.py
@@ -128,7 +128,7 @@ def test_regression_read_dict_loads_normally() -> None:
 
 def test_regression_write_normally() -> None:
     cc = CommentedConfigParser()
-    expected = "[TEST]\ntest=pass\n\n"
+    expected = "[TEST]\ntest=pass\n"
     cc.read_string(expected)
     mock_file = StringIO()
 
@@ -139,7 +139,7 @@ def test_regression_write_normally() -> None:
 
 def test_write_with_no_comments() -> None:
     cc = CommentedConfigParser()
-    expected = "[TEST]\ntest=pass\n\n"
+    expected = "[TEST]\ntest=pass\n"
     cc.read_dict({"TEST": {"test": "pass"}})
     mock_file = StringIO()
 
@@ -181,7 +181,7 @@ def test_issue_46_duplicating_sections(tmp_path: Path) -> None:
     # https://github.com/Preocts/commented-configparser/issues/46
     tmp_file = tmp_path / "issue46_test_file.ini"
     starting_config = "[example]\nfoo = 0\n"
-    expected = "[example]\nfoo = 9\n\n"
+    expected = "[example]\nfoo = 9\n"
     tmp_file.write_text(starting_config, "utf-8")
     cc = CommentedConfigParser()
     cc.read(tmp_file)

--- a/tests/empty_comments_expected.ini
+++ b/tests/empty_comments_expected.ini
@@ -12,4 +12,3 @@ bar = foo
 
 [BIZ]
 baz = bar
-

--- a/tests/header_expected.ini
+++ b/tests/header_expected.ini
@@ -8,4 +8,3 @@
 foo = bar
 # Comment here
 bar = foo
-

--- a/tests/multi_expected.ini
+++ b/tests/multi_expected.ini
@@ -8,4 +8,3 @@ foo = bar
 unique to multi02 = foo
 ; A nice little comment here from multi01
 unique to multi01 = foo
-

--- a/tests/pydocs_expected.ini
+++ b/tests/pydocs_expected.ini
@@ -40,4 +40,3 @@ multiline_values = are
 	deeper than the first line
 	of a value
 # Did I mention we can indent comments, too?
-

--- a/tests/regression_original_expected.ini
+++ b/tests/regression_original_expected.ini
@@ -18,4 +18,3 @@ multi-line =
 	value03
 closing = 0
 # Trailing comment
-


### PR DESCRIPTION
The write process was creating an extra newline at the end of the file. Now it won't do that.

If the input file does not end with a newline, the written result will. As all files should.