### PR TITLE
Preserve blank line formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ with open("myconfig.ini", "w") as savefile:
 ## Results
 
 There is the attempt to retain the original format. Known formats that will not
-be preserved: 
+be preserved:
 
 1. Indents will not be preserved outside of multi-line values
 2. Spacing around assignments will be normalized.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@
 
 ---
 
-A custom ConfigParser class that preserves comments and option casing when writing loaded config out.
+A custom ConfigParser class that preserves comments and most formatting when
+writing loaded config out.
 
-This library gives you a custom class of the standard library's `configparser.ConfigParger` which will preserve the comments of a loaded config file when writing that file back out.
+This library gives you a custom class of the standard library's
+`configparser.ConfigParger` which will preserve the comments of a loaded config
+file when writing that file back out.
 
 ---
 
@@ -58,7 +61,12 @@ with open("myconfig.ini", "w") as savefile:
 
 ## Results
 
-We favor the line spacing choices of the `ConfigParser` class so the input format may not be preserved completely. However, the comments will be preserved.
+There is the attempt to retain the original format. Known formats that will not
+be preserved: 
+
+1. Indents will not be preserved outside of multi-line values
+2. Spacing around assignments will be normalized.
+3. Casing of all options will be written as lowercase.
 
 ### Before
 
@@ -83,7 +91,6 @@ multi-line=
 	value03
 closing=0
 # Trailing comment
-
 ```
 
 ### After
@@ -97,9 +104,10 @@ foo = bar
 trace = false
 logging = true
 ; This is a comment as well
-# so we need to track all of them
-; and many could be between things
 
+# so we need to track all of them
+
+; and many could be between things
 [NEW SECTION]
 # Another comment
 multi-line =
@@ -108,5 +116,4 @@ multi-line =
 	value03
 closing = 0
 # Trailing comment
-
 ```

--- a/tests/empty_comments_expected.ini
+++ b/tests/empty_comments_expected.ini
@@ -4,11 +4,14 @@
 
 [DEFAULT]
 foo = bar
+
 # Comment here
 #
 bar = foo
 ;
 ; Comment here too
 
+
 [BIZ]
 baz = bar
+

--- a/tests/empty_comments_input.ini
+++ b/tests/empty_comments_input.ini
@@ -14,3 +14,4 @@ bar = foo
 
 [BIZ]
 baz=bar
+

--- a/tests/pydocs_expected.ini
+++ b/tests/pydocs_expected.ini
@@ -25,6 +25,7 @@ empty string value here =
 [You can use comments]
 # like this
 ; or this
+
 # By default only in an empty line.
 # Inline comments can be harmful because they prevent users
 # from using the delimiting characters as parts of values.

--- a/tests/regression_original_expected.ini
+++ b/tests/regression_original_expected.ini
@@ -6,9 +6,10 @@ foo = bar
 trace = false
 logging = true
 ; This is a comment as well
-# so we need to track all of them
-; and many could be between things
 
+# so we need to track all of them
+
+; and many could be between things
 [NEW SECTION]
 foo = bar
 # Unique foo


### PR DESCRIPTION
resolves #68

This change treats emtpy lines as comments allowing the preservation of them from read to write.

The changes in #73 are removed here. #73 specifically corrected the ending of the file. Instead, this change takes full control of empty lines. This corrects the issue #73 solved as well as correcting extra empty lines that were appearing between sections during development.