### PR TITLE
Preserve option case between read and write

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ be preserved:
 
 1. Indents will not be preserved outside of multi-line values
 2. Spacing around assignments will be normalized.
-3. Casing of all options will be written as lowercase.
 
 ### Before
 
@@ -85,7 +84,7 @@ logging=true
 	; and many could be between things
 [NEW SECTION]
 # Another comment
-multi-line=
+multiLine=
 	value01
 	value02
 	value03
@@ -110,7 +109,7 @@ logging = true
 ; and many could be between things
 [NEW SECTION]
 # Another comment
-multi-line =
+multiLine =
 	value01
 	value02
 	value03

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "commented-configparser"
 requires-python = ">=3.9"
-description = "Custom ConfigParser class that preserves comments in file when writing"
+description = "A custom ConfigParser class that preserves comments and most formatting when writing loaded config out."
 readme = "README.md"
 license = "MIT"
 authors = [

--- a/src/commentedconfigparser/commentedconfigparser.py
+++ b/src/commentedconfigparser/commentedconfigparser.py
@@ -58,7 +58,15 @@ class CommentedConfigParser(ConfigParser):
 
     def read_file(self, f: Iterable[str], source: str | None = None) -> None:
         content = self._translate_comments([line for line in f])
-        return super().read_file(content.splitlines(), source)
+        self.__is_reading = True
+        super().read_file(content.splitlines(), source)
+        self.__is_reading = False
+
+    def optionxform(self, optionstr: str) -> str:
+        if hasattr(self, "_CommentedConfigParser__is_reading") and self.__is_reading:
+            return optionstr
+
+        return super().optionxform(optionstr)
 
     def write(
         self,

--- a/tests/pydocs_expected.ini
+++ b/tests/pydocs_expected.ini
@@ -12,7 +12,7 @@ values like this = 1000000
 or this = 3.14159265359
 are they treated as numbers? = no
 integers, floats and booleans are held as = strings
-can use the api to get converted values directly = true
+can use the API to get converted values directly = true
 
 [Multiline Values]
 chorus = I'm a lumberjack, and I'm okay

--- a/tests/regression_original_expected.ini
+++ b/tests/regression_original_expected.ini
@@ -18,4 +18,5 @@ multi-line =
 	value02
 	value03
 closing = 0
+caseVariant = 0
 # Trailing comment

--- a/tests/regression_original_input.ini
+++ b/tests/regression_original_input.ini
@@ -18,4 +18,5 @@ multi-line=
 	value02
 	value03
 closing=0
+caseVariant=0
 # Trailing comment


### PR DESCRIPTION
Normally options are normalized to lowercase during the read process. This results in a formatting change on write that can be frustrating if camelCase is used for option names.

This change ensures the `optionxform()` method does not apply the `.lower()` converstion during reading.

Options remain case insensitive while using a ConfigParser object as expected.